### PR TITLE
B/reg term bugfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vbll"
-version = "0.4.8"
+version = "0.4.9"
 description = ""
 authors = ["John Willes <johnwilles@gmail.com>"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os, sys
 
 setup(
     name="vbll",
-    version="0.4.8",
+    version="0.4.9",
     packages=find_packages(),
     install_requires=["torch"],
 )

--- a/vbll/layers/classification.py
+++ b/vbll/layers/classification.py
@@ -525,7 +525,7 @@ class HetClassification(nn.Module):
             kl_term_noise = gaussian_kl(self.M, self.noise_prior_scale)
 
             total_elbo = torch.mean(self.softmax_bound(x, y))
-            total_elbo -= self.regularization_weight * kl_term_ll + kl_term_noise
+            total_elbo -= self.regularization_weight * (kl_term_ll + kl_term_noise)
 
             return -total_elbo
 

--- a/vbll/layers/regression.py
+++ b/vbll/layers/regression.py
@@ -404,7 +404,7 @@ class HetRegression(nn.Module):
             # compute expected KL
             kl_term_ll = torch.mean(grad_correction * expected_gaussian_kl(W, self.prior_scale, expect_sigma_inv))
             kl_term_noise = torch.mean(grad_correction * gaussian_kl(M, self.noise_prior_scale))
-            total_elbo -= self.regularization_weight * kl_term_ll + kl_term_noise
+            total_elbo -= self.regularization_weight * (kl_term_ll + kl_term_noise)
             return -total_elbo
 
         return loss_fn


### PR DESCRIPTION
This pull request includes a version bump for the `vbll` package and minor fixes to the loss function calculations in two files to ensure proper operator precedence. Below is a summary of the changes:

### Version Update:
* Updated the version of the `vbll` package from `0.4.8` to `0.4.9` in both `pyproject.toml` and `setup.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L6-R6)

### Bug Fixes:
* Corrected operator precedence in the `loss_fn` function in `vbll/layers/classification.py` by adding parentheses around `(kl_term_ll + kl_term_noise)` to ensure proper calculation of the regularization term.
* Applied the same fix for operator precedence in the `loss_fn` function in `vbll/layers/regression.py`.